### PR TITLE
FEATURE: support images separated by newlines

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -100,7 +100,8 @@ api.onToolbarCreate(function(toolbar) {
       return e.applySurround(
         '<div data-theme-tiles="1">\n\n',
         "\n\n</div>",
-        "tiles_add_images_prompt"
+        "tiles_add_images_prompt",
+        { multiline: false }
       );
     }
   });


### PR DESCRIPTION
Discourse by default splits uploaded images using newlines starting from [this commit](https://github.com/discourse/discourse/commit/d3b05f8a9cd678e2abba24a790d075a113e777c9).
