### PR TITLE
FIX: support Ember 5

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -1,4 +1,4 @@
-<script>
+<script type="text/discourse-plugin" version="0.8">
   // Colcade.js
   // Author: David DeSandro
   // Github: https://github.com/desandro/colcade


### PR DESCRIPTION
This partially fixes the component to eliminate this error and run the requisite JS... but it seems to have other ongoing issues (the component is deprecated, but if someone wants a little more time this might help) 

![Screenshot 2024-01-25 at 5 19 22 PM](https://github.com/discourse/Discourse-Tiles-image-gallery/assets/1681963/4b879188-fdca-41c5-b31f-cc95af0fd8ea)
